### PR TITLE
do not register a thread-local destructor in ThreadLocal::get

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,7 +182,7 @@ impl<T: Send> ThreadLocal<T> {
 
     /// Returns the element for the current thread, if it exists.
     pub fn get(&self) -> Option<&T> {
-        self.get_inner(thread_id::get())
+        thread_id::try_get().and_then(|id| self.get_inner(id))
     }
 
     /// Returns the element for the current thread, or creates it if it doesn't

--- a/src/thread_id.rs
+++ b/src/thread_id.rs
@@ -107,6 +107,13 @@ cfg_if::cfg_if! {
             }
         }
 
+        /// Returns a thread ID for the current thread, **not** allocating one if needed.
+        /// This avoids registering a thread-local destructor.
+        #[inline]
+        pub(crate) fn try_get() -> Option<Thread> {
+            unsafe { THREAD }
+        }
+
         /// Returns a thread ID for the current thread, allocating one if needed.
         #[inline]
         pub(crate) fn get() -> Thread {
@@ -151,6 +158,13 @@ cfg_if::cfg_if! {
                 let _ = THREAD.try_with(|thread| thread.set(None));
                 THREAD_ID_MANAGER.lock().unwrap().free(self.id.get());
             }
+        }
+
+        /// Returns a thread ID for the current thread, **not** allocating one if needed.
+        /// This avoids registering a thread-local destructor.
+        #[inline]
+        pub(crate) fn try_get() -> Option<Thread> {
+            THREAD.with(|thread| thread.get())
         }
 
         /// Returns a thread ID for the current thread, allocating one if needed.


### PR DESCRIPTION
I wanted to use `ThreadLocal` in an allocator I was making. My design assumed that the thread local was registered on each thread, but it would obviously still need to work if I didn't register it in time (eg for custom thread names), or some dependency created a thread internally with no support for custom hooks. 

Unfortunately that was not possible even if I only used `ThreadLocal::get` since it currently always calls `get_slow`. If no thread local value is going to be created, then allocating an ID is unnecessary and it causes Rust to abort the process as global allocators are not allowed to register thread local destructors in the current version.

I've tested this code against my allocator and it no longer aborts like it used to.